### PR TITLE
Fix session rollback handlers

### DIFF
--- a/app/admin/base/base_view.py
+++ b/app/admin/base/base_view.py
@@ -6,40 +6,40 @@ from flask_admin.contrib import sqla
 class ModelViewWithSessionRollback(sqla.ModelView):
     def handle_exception(self, e):
         self.session.rollback()
-        return super(e)
+        return super().handle_exception(e)
 
     def handle_user_exception(self, e):
         self.session.rollback()
-        return super(e)
+        return super().handle_user_exception(e)
 
     def handle_view_exception(self, e):
         self.session.rollback()
-        return super(e)
+        return super().handle_view_exception(e)
 
 
 class BaseModelViewWithSessionRollback(model.BaseModelView):
     def handle_exception(self, e):
         self.session.rollback()
-        return super(e)
+        return super().handle_exception(e)
 
     def handle_user_exception(self, e):
         self.session.rollback()
-        return super(e)
+        return super().handle_user_exception(e)
 
     def handle_view_exception(self, e):
         self.session.rollback()
-        return super(e)
+        return super().handle_view_exception(e)
 
 
 class BaseViewWithSessionRollback(flask_admin.BaseView):
     def handle_exception(self, e):
         self.session.rollback()
-        return super(e)
+        return super().handle_exception(e)
 
     def handle_user_exception(self, e):
         self.session.rollback()
-        return super(e)
+        return super().handle_user_exception(e)
 
     def handle_view_exception(self, e):
         self.session.rollback()
-        return super(e)
+        return super().handle_view_exception(e)


### PR DESCRIPTION
## Summary
- properly call base handler methods for rollback views

## Testing
- `pytest -q` *(fails: No module named 'mmlib')*

------
https://chatgpt.com/codex/tasks/task_e_68425a3f56548324b37eacc3c1406c35